### PR TITLE
fix console command methods

### DIFF
--- a/src/Console/GenerateSealingKeyPair.php
+++ b/src/Console/GenerateSealingKeyPair.php
@@ -18,7 +18,7 @@ final class GenerateSealingKeyPair extends GenerateCommand
     /**
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $pair = sodium_crypto_box_keypair();
 

--- a/src/Console/GenerateSharedAuthenticationKey.php
+++ b/src/Console/GenerateSharedAuthenticationKey.php
@@ -18,7 +18,7 @@ final class GenerateSharedAuthenticationKey extends GenerateCommand
     /**
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $key = Base64UrlSafe::encode(random_bytes(SODIUM_CRYPTO_AUTH_KEYBYTES));
 

--- a/src/Console/GenerateSharedEncryptionKey.php
+++ b/src/Console/GenerateSharedEncryptionKey.php
@@ -18,7 +18,7 @@ final class GenerateSharedEncryptionKey extends GenerateCommand
     /**
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $key = Base64UrlSafe::encode(random_bytes(SODIUM_CRYPTO_AEAD_CHACHA20POLY1305_KEYBYTES));
 

--- a/src/Console/GenerateSigningKeyPair.php
+++ b/src/Console/GenerateSigningKeyPair.php
@@ -18,7 +18,7 @@ final class GenerateSigningKeyPair extends GenerateCommand
     /**
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $pair = sodium_crypto_sign_keypair();
 


### PR DESCRIPTION
Hi,

In all four console commands, it seems the `handle()` method was missing, leading to errors like `Method MCordingley\LaravelSapient\Console\GenerateSealingKeyPair::handle() does not exist`.  Upon investigation, it seems that the method that should have been called `handle()` was instead called `fire()`.  Editing this allowed the commands to complete, and the keys added to the `.env` file.

-Alex